### PR TITLE
Clean up components for demo

### DIFF
--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -176,15 +176,17 @@ const ChipTip: React.FC<ChipTipProps> = ({ children, onClose, visible }) => {
         display: isVisible ? "flex" : "none",
         maxWidth: 244,
         fontSize: "0.75rem",
-        margin: "0 -8px",
-        padding: "8px 8px 16px",
-        borderBottom: "1px solid #dee2e6",
+        background: "var(--color-primary)",
+        margin: "-8px -8px 0",
+        padding: "12px 8px",
+        borderTopLeftRadius: "var(--border-radius-lg)",
+        borderTopRightRadius: "var(--border-radius-lg)",
       }}
     >
-      <div style={{ paddingRight: 16 }}>{children}</div>
-
+      <div style={{ fontSize: "1rem", paddingRight: 8 }}>⚡️</div>
+      <div style={{ color: "#fff", paddingRight: 16 }}>{children}</div>
       <button
-        style={{ background: "none", fontSize: "1rem" }}
+        style={{ background: "none", fontSize: "1rem", color: "#fff" }}
         onClick={handleOnClose}
       >
         &times;

--- a/src/actions/actionProperties.tsx
+++ b/src/actions/actionProperties.tsx
@@ -66,6 +66,7 @@ import { hasStrokeColor } from "../scene/comparisons";
 import Scene from "../scene/Scene";
 import { arrayToMap } from "../utils";
 import { register } from "./register";
+import React, { useState } from "react";
 import { Consumer as SBConsumer } from "switchboard/packages/sdk/lib/cjs/packages/@react";
 const changeProperty = (
   elements: readonly ExcalidrawElement[],
@@ -155,6 +156,43 @@ export const actionChangeStrokeColor = register({
   ),
 });
 
+type ChipTipProps = {
+  children: string;
+  onClose(): void;
+  visible: boolean;
+};
+
+const ChipTip: React.FC<ChipTipProps> = ({ children, onClose, visible }) => {
+  const [isVisible, setIsVisible] = useState(visible);
+
+  const handleOnClose = () => {
+    setIsVisible(false);
+    onClose();
+  };
+
+  return (
+    <div
+      style={{
+        display: isVisible ? "flex" : "none",
+        maxWidth: 244,
+        fontSize: "0.75rem",
+        margin: "0 -8px",
+        padding: "8px 8px 16px",
+        borderBottom: "1px solid #dee2e6",
+      }}
+    >
+      <div style={{ paddingRight: 16 }}>{children}</div>
+
+      <button
+        style={{ background: "none", fontSize: "1rem" }}
+        onClick={handleOnClose}
+      >
+        &times;
+      </button>
+    </div>
+  );
+};
+
 export const actionShowStrokeToolTip = register({
   name: "showStrokeToolTip",
   perform: () => {
@@ -164,38 +202,18 @@ export const actionShowStrokeToolTip = register({
     <>
       <SBConsumer>
         {(sbState) => {
-          if (
-            sbState?.surfaces &&
-            sbState?.surfaces.strokeToolTip &&
-            sbState?.surfaces.strokeToolTip?.component?.active === true
-          ) {
+          if (sbState?.surfaces && sbState?.surfaces.strokeToolTip) {
             return (
-              <p
-                style={{
-                  direction: "ltr",
-                  unicodeBidi: "embed",
-                  fontSize: "0.8em",
-                }}
-                id="strokeToolTip"
+              <ChipTip
+                visible={sbState?.surfaces.strokeToolTip?.component?.active}
+                onClose={() =>
+                  sbState.setComponentInactive(
+                    sbState.surfaces?.strokeToolTip.componentName,
+                  )
+                }
               >
-                We redesigned the shape panel <br></br>to give you more stroke
-                styles &ensp;
-                <button
-                  type="button"
-                  style={{ alignSelf: "end" }}
-                  onClick={() => {
-                    const toolTip = document.getElementById("strokeToolTip");
-                    if (toolTip) {
-                      toolTip.style.display = "none";
-                      sbState.setComponentInactive(
-                        sbState.surfaces?.strokeToolTip.componentName,
-                      );
-                    }
-                  }}
-                >
-                  x
-                </button>
-              </p>
+                We redesigned the shape panel to give you more stroke styles
+              </ChipTip>
             );
           }
         }}

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -68,6 +68,10 @@ import { newElementWith } from "../element/mutateElement";
 import { isInitializedImageElement } from "../element/typeChecks";
 import { loadFilesFromFirebase } from "./data/firebase";
 import Joyride, { EVENTS, ACTIONS } from "react-joyride";
+import {
+  CallBackProps as JoyrideCallBackProps,
+  Step as JoyrideStep,
+} from "react-joyride/types";
 import React from "react";
 import {
   Consumer as SBConsumer,
@@ -702,6 +706,105 @@ const ExcalidrawApp = () => {
           {(sbState) => {
             if (sbState?.surfaces && sbState?.tours) {
               const welcome_tour = sbState?.tours.welcome_tour;
+
+              const tourCallback = (operation: JoyrideCallBackProps) => {
+                const { step, action, type } = operation;
+                if (window.performance) {
+                }
+                if (performance.navigation.type === 1) {
+                  console.info("reload");
+                  if (
+                    window.sessionStorage.getItem("firstReload") === "true" ||
+                    window.sessionStorage.getItem("firstReload") === "null"
+                  ) {
+                    window.sessionStorage.setItem("priorTarget", "blahblah");
+                    window.sessionStorage.setItem("firstReload", "false");
+                  }
+                } else {
+                  console.info("!reload");
+
+                  window.sessionStorage.setItem("firstReload", "true");
+                }
+                if (
+                  [
+                    EVENTS.STEP_AFTER.valueOf(),
+                    EVENTS.TARGET_NOT_FOUND.valueOf(),
+                  ].includes(type) &&
+                  JSON.stringify(step.target) !==
+                    window.sessionStorage.getItem("priorTarget") &&
+                  [ACTIONS.NEXT.valueOf()].includes(action)
+                ) {
+                  sbState.progressTour(welcome_tour.componentName);
+                  window.sessionStorage.setItem(
+                    "priorTarget",
+                    JSON.stringify(step.target),
+                  );
+                } else if (
+                  [EVENTS.STEP_AFTER.valueOf()].includes(type) &&
+                  JSON.stringify(step.target) !==
+                    window.sessionStorage.getItem("priorTarget") &&
+                  [ACTIONS.PREV.valueOf()].includes(action)
+                ) {
+                  sbState.regressTour(welcome_tour.componentName);
+                  window.sessionStorage.setItem("priorTarget", "foooobaaarrr");
+                }
+              };
+
+              const tourSteps: Array<JoyrideStep> = [
+                {
+                  target: "#root",
+                  content: (
+                    <React.Fragment>
+                      Welcome to Excalidraw the best way to digitally sketch
+                      ideas. Let's start
+                    </React.Fragment>
+                  ),
+                  event: "hover",
+                  placement: "center",
+                  hideCloseButton: true,
+                },
+                {
+                  target: "#SB-rectangle",
+                  content: (
+                    <React.Fragment>
+                      Let's start by creating your first shape. Click the square
+                      and click and drag to draw.
+                    </React.Fragment>
+                  ),
+                  placement: "top",
+                  event: "hover",
+                  spotlightClicks: true,
+                  hideCloseButton: true,
+                },
+                {
+                  target: "body",
+                  content: (
+                    <React.Fragment>
+                      After drawing the square let's add some text to it. Double
+                      click the square text
+                    </React.Fragment>
+                  ),
+                  event: "click",
+                  spotlightClicks: true,
+                  placement: "bottom-end",
+                  placementBeacon: "right",
+                  disableOverlayClose: true,
+                  offset: -450,
+                  hideCloseButton: true,
+                },
+                {
+                  target: "#SB-export",
+                  content: (
+                    <React.Fragment>
+                      Great now let's share with a coworker
+                    </React.Fragment>
+                  ),
+                  event: "hover",
+                  placement: "auto",
+                  hideCloseButton: true,
+                },
+              ];
+
               return (
                 <div>
                   <Joyride
@@ -709,111 +812,9 @@ const ExcalidrawApp = () => {
                     continuous={true}
                     showProgress={true}
                     debug={true}
-                    callback={(operation) => {
-                      const { step, action, type } = operation;
-                      if (window.performance) {
-                      }
-                      if (performance.navigation.type === 1) {
-                        console.info("reload");
-                        if (
-                          window.sessionStorage.getItem("firstReload") ===
-                            "true" ||
-                          window.sessionStorage.getItem("firstReload") ===
-                            "null"
-                        ) {
-                          window.sessionStorage.setItem(
-                            "priorTarget",
-                            "blahblah",
-                          );
-                          window.sessionStorage.setItem("firstReload", "false");
-                        }
-                      } else {
-                        console.info("!reload");
-
-                        window.sessionStorage.setItem("firstReload", "true");
-                      }
-                      if (
-                        [
-                          EVENTS.STEP_AFTER.valueOf(),
-                          EVENTS.TARGET_NOT_FOUND.valueOf(),
-                        ].includes(type) &&
-                        JSON.stringify(step.target) !==
-                          window.sessionStorage.getItem("priorTarget") &&
-                        [ACTIONS.NEXT.valueOf()].includes(action)
-                      ) {
-                        sbState.progressTour(welcome_tour.componentName);
-                        window.sessionStorage.setItem(
-                          "priorTarget",
-                          JSON.stringify(step.target),
-                        );
-                      } else if (
-                        [EVENTS.STEP_AFTER.valueOf()].includes(type) &&
-                        JSON.stringify(step.target) !==
-                          window.sessionStorage.getItem("priorTarget") &&
-                        [ACTIONS.PREV.valueOf()].includes(action)
-                      ) {
-                        sbState.regressTour(welcome_tour.componentName);
-                        window.sessionStorage.setItem(
-                          "priorTarget",
-                          "foooobaaarrr",
-                        );
-                      }
-                    }}
+                    callback={tourCallback}
                     stepIndex={welcome_tour?.currentStep}
-                    steps={[
-                      {
-                        target: "#root",
-                        content: (
-                          <React.Fragment>
-                            Welcome to Excalidraw the best way to digitally
-                            sketch ideas. Let's start
-                          </React.Fragment>
-                        ),
-                        event: "hover",
-                        placement: "center",
-                        hideCloseButton: true,
-                      },
-                      {
-                        target: "#SB-rectangle",
-                        content: (
-                          <React.Fragment>
-                            Let's start by creating your first shape. Click the
-                            square and click and drag to draw.
-                          </React.Fragment>
-                        ),
-                        placement: "top",
-                        event: "hover",
-                        spotlightClicks: true,
-                        hideCloseButton: true,
-                      },
-                      {
-                        target: "body",
-                        content: (
-                          <React.Fragment>
-                            After drawing the square let's add some text to it.
-                            Double click the square text
-                          </React.Fragment>
-                        ),
-                        event: "click",
-                        spotlightClicks: true,
-                        placement: "bottom-end",
-                        placementBeacon: "right",
-                        disableOverlayClose: true,
-                        offset: -450,
-                        hideCloseButton: true,
-                      },
-                      {
-                        target: "#SB-export",
-                        content: (
-                          <React.Fragment>
-                            Great now let's share with a coworker
-                          </React.Fragment>
-                        ),
-                        event: "hover",
-                        placement: "auto",
-                        hideCloseButton: true,
-                      },
-                    ]}
+                    steps={tourSteps}
                   />
                 </div>
               );

--- a/src/excalidraw-app/index.tsx
+++ b/src/excalidraw-app/index.tsx
@@ -695,6 +695,7 @@ const ExcalidrawWrapper = () => {
 
 const ExcalidrawApp = () => {
   const user = "1";
+
   return (
     //User 1 shows tour
     //User 2 shows inline surface
@@ -756,7 +757,7 @@ const ExcalidrawApp = () => {
                   content: (
                     <React.Fragment>
                       Welcome to Excalidraw the best way to digitally sketch
-                      ideas. Let's start
+                      ideas. Let's start sketching...
                     </React.Fragment>
                   ),
                   event: "hover",
@@ -781,7 +782,7 @@ const ExcalidrawApp = () => {
                   content: (
                     <React.Fragment>
                       After drawing the square let's add some text to it. Double
-                      click the square text
+                      click the square text.
                     </React.Fragment>
                   ),
                   event: "click",
@@ -796,7 +797,7 @@ const ExcalidrawApp = () => {
                   target: "#SB-export",
                   content: (
                     <React.Fragment>
-                      Great now let's share with a coworker
+                      Great now let's share this work of art with a coworker.
                     </React.Fragment>
                   ),
                   event: "hover",


### PR DESCRIPTION
## Tour 

![image](https://user-images.githubusercontent.com/604167/149564994-bbe9f858-ecda-4bd9-97cb-1a0d21b13327.png)

Moved the larger props out into constants so the `Joyride` component is more easily interpreted. I would suggest folding the `tourCallback` and `tourSteps` since they're not super important to get the point across.

Another thing that would be good to do here is give some brief context on what `react-joyride` is. Referring to it as "an open source tour UI library" and likening it to tour components that the prospect would have in their codebase would be good.

## Chip

![image](https://user-images.githubusercontent.com/604167/149563736-6269acc1-5ba5-49b1-80f6-0a18d820b5a3.png)

Updated the chip look to make it more visible in the UI.

![image](https://user-images.githubusercontent.com/604167/149563875-5f7e839a-f9ea-4fd3-b85f-257b80909156.png)

Created a new component called `ChipTip` to house (and obfuscate) the decoration aspects of the chip so we can more easily map SB state and SDK methods to modify state to the UI.

Here we can point to how the `visible` prop consumes SB state and the `onClose` prop initiates the state change via the SDK.